### PR TITLE
Spelling mistake and proposing a new name for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-lpd-httpd",
+  "name": "ldp-httpd",
   "description": "Read-write linked data web server based on express and rdflib.js",
   "version": "0.0.1",
   "private": true,


### PR DESCRIPTION
I did:
- rename `lpd` into `ldp` (I suppose?)
- remove the `node-` prefix in the `package.json` so in case this will go on npm, it will have a clean name
