### PR TITLE
Test that fails when accessTo is set wrong

### DIFF
--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -855,4 +855,15 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       rm('/accounts-acl/tim.localhost/write-acl/default-for-new/test-file.ttl')
     })
   })
+
+  describe('Wrongly set accessTo', function () {
+    it('user1 should be able to access test directory', function (done) {
+      var options = createOptions('/dot-acl/', 'user1')
+      request.head(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 403)
+        done()
+      })
+    })
+  })
 })

--- a/test/resources/accounts-acl/tim.localhost/dot-acl/.acl
+++ b/test/resources/accounts-acl/tim.localhost/dot-acl/.acl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+
+<#DotAcl> a acl:Authorization ;
+    acl:accessTo <./.acl> ;
+    acl:agent <https://tim.localhost:7777/profile/card#me> ;
+    acl:mode acl:Read .


### PR DESCRIPTION
I made this test in case there was something more serious behind that many of hour tests had a authorization that said `acl:accessTo <./.acl> `, but since this test fails, it seems like things are OK.

I don't know if we want to merge it, I guess the more the merrier.