### PR TITLE
publish to docker hub via github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,55 @@ jobs:
     - run: npm install -g solid-server-*.tgz
     # Run the Solid test-suite
     - run: bash test/surface/run-solid-test-suite.sh $BRANCH_NAME
+
+  # TODO: The pipeline should automate publication to npm, so that the docker build gets the correct version
+  #       This job will only dockerize solid-server@latest / solid-server@<tag-name> from npmjs.com!
+  docker-hub:
+    needs: build
+    name: Publish to docker hub
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Lint dockerfile
+        working-directory: docker-image
+        run: pwd && ls -lah && make lint
+
+      - name: Run tests
+        working-directory: docker-image
+        run: make test
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "(?<version>.*)"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: nodesolidserver/node-solid-server
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker-image/src
+          build-args: SOLID_SERVER_VERSION=${{ steps.tagName.outputs.version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-image/src/Dockerfile
+++ b/docker-image/src/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:10-alpine
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache openssl
 
 ARG SOLID_SERVER_VERSION=latest


### PR DESCRIPTION
Since docker hub changed there policy for automatic builds, this PR adds the build and publication process of the docker image to the github actions ci pipelline.

- Pushes to `main` will publish `nodesolidserver/node-solid-server:main` containing `solid-server@latest` version from npm
- Pushes to a  `<tag>` will publish `nodesolidserver/node-solid-server:<tag>` and `nodesolidserver/node-solid-server:latest` containing `solid-server@<tag>` version from npm