### PR TITLE
Use secure uuid.v4 as session cookie secret

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -302,7 +302,7 @@ function initAuthentication (app, argv) {
 function sessionSettings (secureCookies, host) {
   const sessionSettings = {
     name: 'nssidp.sid',
-    secret: uuid.v1(),
+    secret: uuid.v4(),
     saveUninitialized: false,
     resave: false,
     rolling: true,


### PR DESCRIPTION
### Summary

This changes the secret used to create session cookies from the insecure uuid.v1 to the secure uuid.v4. The `secret` does not *seem* important for the security of the sessions, however as best practice we should change it to uuid.v4.

### Details

To create session cookies NSS uses [express-session](https://expressjs.com/en/resources/middleware/session.html). The cookie creation depends on a `secret` option, which should ideally be random characters according to the documentation. It is used to sign the session cookies (`nssidp.sid`).

However, as detailed in [this post](https://versprite.com/blog/universally-unique-identifiers/), the uuid v1 does not include randomness. Instead it depends on the current timestamp, the clock sequence and the MAC. This is not sufficiently random for a cookie secret.

An attacker can obtain the MAC and clock sequence from another uuid, in particular they can POST a new file and it will be created with a new uuid. With this, the knowledge of the approximate server starting time, and any valid session cookie (e.g. their own), they can bruteforce the `secret` uuid used by the server. I've tested this part, and locally I bruteforced the `secret` pretty quickly (e.g. if the server was started within one specific hour, I could bruteforce it within less than a day).

### Impact

Likely no direct impact. From what I understand, it is a security in depth mechanism that could help against bad custom session id generation (which NSS currently does not use) and the possibility to detect bruteforcing attempts early on (which does not matter as NSS only seems to use the MemoryStore). The express-session library internally creates a 24-byte random session id. To impersonate other persons, one would need to know this id. Knowing the `secret` allows to bypass the signature verification, but gives no clue about other peoples session ids. A lot of discussion on this is [here](https://github.com/expressjs/session/issues/176).

### Draft PR

I've marked it as a draft pull request, as I didn't test it locally. I wouldn't know how this change could break something, but if you want to be sure please try it locally first.