### PR TITLE
Change translation error (500) to not acceptable (406)

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -116,10 +116,9 @@ async function handler (req, res, next) {
 
   // If it is not in our RDFs we can't even translate,
   // Sorry, we can't help
-  if (!possibleRDFType) {
-    return next(error(406, 'Cannot serve requested type: ' + contentType))
+  if (!possibleRDFType || !RDFs.includes(requestedType)) {
+    return next(error(406, 'Cannot serve requested type: ' + requestedType))
   }
-
   try {
     // Translate from the contentType found to the possibleRDFType desired
     const data = await translate(stream, baseUri, contentType, possibleRDFType)
@@ -127,7 +126,8 @@ async function handler (req, res, next) {
     res.setHeader('Content-Type', possibleRDFType)
     res.send(data)
     return next()
-  } catch (err) {
+  }
+  catch (err) {
     debug('error translating: ' + req.originalUrl + ' ' + contentType + ' -> ' + possibleRDFType + ' -- ' + 406 + ' ' + err.message)
     return next(error(406, 'Cannot serve requested type: ' + requestedType))
   }

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -128,8 +128,8 @@ async function handler (req, res, next) {
     res.send(data)
     return next()
   } catch (err) {
-    debug('error translating: ' + req.originalUrl + ' ' + contentType + ' -> ' + possibleRDFType + ' -- ' + 500 + ' ' + err.message)
-    return next(error(500, 'Error translating between RDF formats'))
+    debug('error translating: ' + req.originalUrl + ' ' + contentType + ' -> ' + possibleRDFType + ' -- ' + 406 + ' ' + err.message)
+    return next(error(406, 'Cannot serve requested type: ' + requestedType))
   }
 }
 


### PR DESCRIPTION
The problem is that the server returns a 500 in a situation where it tries to parse a document that it can't parse as RDF, and says "Error translating between RDF formats". This happens when the request (Accept header) includes a media type of a concrete RDF syntax, and the server attempts to parse the document using one of its RDF parsers.

This is not a 500, "unexpected condition" per se. It is an expected condition.

The server should be responding with a 406, not acceptable, because client is asking for a particular representation of the resource (using an RDF media type) and the server is unable to provide one.

I think the flow of code leading up to this can be better / refactored but I didn't want to touch it in this PR.

---

*Message to application developers*: your application can get around the current issue (500) by including `*/*` (e.g., `*/*; q=0.1`) in `Accept`, which is a reasonably useful thing to do but YMMV. Your application will then get a 200 representation (whatever the native format of the file/resource is on) instead of a 500. If this PR is merged, your application may get a 406 or 200, which is arguably better to work with than a 500.