### PR TITLE
Try to run the latest versions of webid, crud and wac tests

### DIFF
--- a/test/surface/run-solid-test-suite.sh
+++ b/test/surface/run-solid-test-suite.sh
@@ -41,26 +41,14 @@ function runTests {
     --env-file test/surface/$1-env.list solidtestsuite/$1:$2
 }
 
-function runTestsFromGit {
-  docker build https://github.com/solid-contrib/$1.git#$2 -t $1
-
-  echo "Running web-access-control-tests against server with cookie $COOKIE_server"
-  docker run --rm --network=testnet \
-    --env COOKIE="$COOKIE_server" \
-    --env COOKIE_ALICE="$COOKIE_server" \
-    --env COOKIE_BOB="$COOKIE_thirdparty" \
-    --env-file test/surface/$1-env.list $1
-}
-
 # ...
 teardown || true
 setup $1
 waitForNss server
-runTests webid-provider-tests v2.0.3
-runTestsFromGit solid-crud-tests v6.0.0-issue#1743
+runTests webid-provider-tests v2.1.1
+runTests solid-crud-tests v7.0.6
 waitForNss thirdparty
-# runTests web-access-control-tests v7.1.0
-runTestsFromGit web-access-control-tests patchAppendNewDocument
+runTests web-access-control-tests v7.1.0
 teardown
 
 # To debug, e.g. running web-access-control-tests jest interactively,


### PR DESCRIPTION
I got this passing:
* git checkout 73e73c84e4e7a8602511569441f8c793439739ac
* webid-provider-tests v2.0.3
* solid-crud-tests v6.0.0
* web-access-control-tests v7.1.0

To do:
* [ ] use latest main branch of NSS
* [ ] use webid-provider-tests 2.1.1
* [ ] use solid-crud-tests v7.0.6