### PR TITLE
Update put.js send 200 or 204 depending on pre-existance of resource

### DIFF
--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -62,7 +62,7 @@ async function putStream (req, res, next, stream = req) {
   // try {
   // Obtain details of the target resource
   let resourceExists = true
-  let returnStatus = 201;
+  let returnStatus = 201
   try {
     // First check if the file already exists
     await ldp.resourceMapper.mapUrlToFile({ url: req })
@@ -71,7 +71,7 @@ async function putStream (req, res, next, stream = req) {
       res.sendStatus(412)
       return next()
     }
-    returnStatus = 200;
+    returnStatus = 200
   } catch (err) {
     resourceExists = false
   }

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -79,7 +79,7 @@ async function putStream (req, res, next, stream = req) {
     // Fails with Append on existing resource
     if (!req.originalUrl.endsWith('.acl')) await checkPermission(req, resourceExists)
     await ldp.put(req, stream, getContentType(req.headers))
-    res.sendStatus(returnStatus)
+    res.sendStatus(resourceExists ? 204 : 201)
     return next()
   } catch (err) {
     err.message = 'Can\'t write file/folder: ' + err.message

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -71,7 +71,7 @@ async function putStream (req, res, next, stream = req) {
       res.sendStatus(412)
       return next()
     }
-    returnStatus = 200
+    returnStatus = 204 // if content is sent back change to 200
   } catch (err) {
     resourceExists = false
   }

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -62,7 +62,6 @@ async function putStream (req, res, next, stream = req) {
   // try {
   // Obtain details of the target resource
   let resourceExists = true
-  let returnStatus = 201
   try {
     // First check if the file already exists
     await ldp.resourceMapper.mapUrlToFile({ url: req })
@@ -71,7 +70,6 @@ async function putStream (req, res, next, stream = req) {
       res.sendStatus(412)
       return next()
     }
-    returnStatus = 204 // if content is sent back change to 200
   } catch (err) {
     resourceExists = false
   }

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -62,6 +62,7 @@ async function putStream (req, res, next, stream = req) {
   // try {
   // Obtain details of the target resource
   let resourceExists = true
+  let returnStatus = 201;
   try {
     // First check if the file already exists
     await ldp.resourceMapper.mapUrlToFile({ url: req })
@@ -70,6 +71,7 @@ async function putStream (req, res, next, stream = req) {
       res.sendStatus(412)
       return next()
     }
+    returnStatus = 200;
   } catch (err) {
     resourceExists = false
   }
@@ -77,7 +79,7 @@ async function putStream (req, res, next, stream = req) {
     // Fails with Append on existing resource
     if (!req.originalUrl.endsWith('.acl')) await checkPermission(req, resourceExists)
     await ldp.put(req, stream, getContentType(req.headers))
-    res.sendStatus(201)
+    res.sendStatus(returnStatus)
     return next()
   } catch (err) {
     err.message = 'Can\'t write file/folder: ' + err.message

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -143,7 +143,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         options.body = ''
         request.put(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 201)
+          assert.equal(response.statusCode, 204)
           done()
         })
       })
@@ -214,7 +214,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         options.body = ''
         request.put(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 201) // 403) is this a must ?
+          assert.equal(response.statusCode, 204) // 403) is this a must ?
           done()
         })
       })
@@ -240,7 +240,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         options.body = '<a> <b> <c> .'
         request.put(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 201)
+          assert.equal(response.statusCode, 204)
           done()
         })
       })
@@ -283,7 +283,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       '\n <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>.'
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
+        assert.equal(response.statusCode, 204)
         done()
       })
     })
@@ -456,7 +456,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.body = body
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
+        assert.equal(response.statusCode, 204)
         done()
       })
     })
@@ -606,7 +606,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.body = '<a> <b> <c> .\n'
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
+        assert.equal(response.statusCode, 204)
         done()
       })
     })
@@ -809,7 +809,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.body = body
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
+        assert.equal(response.statusCode, 204)
         done()
       })
     })
@@ -834,7 +834,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.body = '<a> <b> <c> .\n'
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
+        assert.equal(response.statusCode, 204)
         done()
       })
     })
@@ -860,7 +860,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.body = '<d> <e> <f> .\n'
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
+        assert.equal(response.statusCode, 204)
         done()
       })
     })

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -565,7 +565,7 @@ describe('HTTP APIs', function () {
       server.put('/put-resource-1.ttl')
         .send(putRequestBody)
         .set('content-type', 'text/turtle')
-        .expect(201)
+        .expect(204)
         .end(function (err) {
           if (err) return done(err)
           if (fs.existsSync(path.join(__dirname, '../resources/put-resource-1.ttl$.txt'))) {
@@ -646,28 +646,28 @@ describe('HTTP APIs', function () {
           .expect(201, done)
       }
     )
-    it('should return 201 code when trying to put to a container',
+    it('should return 204 code when trying to put to a container',
       function (done) {
         server.put('/foo/bar/test/')
           .set('content-type', 'text/turtle')
           .set('link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
-          .expect(201, done)
+          .expect(204, done)
       }
     )
-    it('should return 201 when trying to put to a container without content-type',
+    it('should return 204 when trying to put to a container without content-type',
       function (done) {
         server.put('/foo/bar/test/')
           // .set('content-type', 'text/turtle')
           .set('link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
-          .expect(201, done)
+          .expect(204, done)
       }
     )
-    it('should return 201 code when trying to put to a container',
+    it('should return 204 code when trying to put to a container',
       function (done) {
         server.put('/foo/bar/test/')
           .set('content-type', 'text/turtle')
           .set('link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
-          .expect(201, done)
+          .expect(204, done)
       }
     )
     it('should return a 400 error when trying to PUT a container with a name that contains a reserved suffix',

--- a/test/integration/validate-tts.js
+++ b/test/integration/validate-tts.js
@@ -20,7 +20,7 @@ describe('HTTP requests with invalid Turtle syntax', () => {
       server.put('/invalid1.ttl')
         .send(invalidTurtleBody)
         .set('content-type', 'text/turtle')
-        .expect(201, done)
+        .expect(204, done)
     })
 
     it('is not allowed with invalid ACL files', (done) => {


### PR DESCRIPTION
The HTTP spec says that the Server MUST return a 200 or 204 if PUT replaces and existing resource.  See second paragraph of https://httpwg.org/specs/rfc9110#PUT.

Brought up by @CxRes.