### PR TITLE
fix: Return 201 when PATCH creates a new resource

### DIFF
--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -91,8 +91,8 @@ async function patchHandler (req, res, next) {
       return writeGraph(graph, resource, ldp.resourceMapper.resolveFilePath(req.hostname), ldp.serverUri)
     })
 
-    // Send the result to the client
-    res.sendStatus(resourceExists ? 200 : 201)
+    // Send the status and result to the client
+    res.status(resourceExists ? 200 : 201)
     res.send(result)
   } catch (err) {
     return next(err)

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -92,6 +92,7 @@ async function patchHandler (req, res, next) {
     })
 
     // Send the result to the client
+    res.sendStatus(resourceExists ? 200 : 201)
     res.send(result)
   } catch (err) {
     return next(err)

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -557,7 +557,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.headers['content-type'] = 'application/sparql-update'
       request.patch(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
+        assert.equal(response.statusCode, 201)
         done()
       })
     })
@@ -616,7 +616,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       options.headers['content-type'] = 'application/sparql-update'
       request.patch(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
+        assert.equal(response.statusCode, 201)
         done()
       })
     })

--- a/test/integration/patch-sparql-update-test.js
+++ b/test/integration/patch-sparql-update-test.js
@@ -22,7 +22,7 @@ describe('PATCH through application/sparql-update', function () {
     server.patch('/notExisting.ttl')
       .set('content-type', 'application/sparql-update')
       .send('INSERT DATA { :test  :hello 456 .}')
-      .expect(200)
+      .expect(201)
       .end(function (err, res, body) {
         assert.equal(
           read('sampleContainer/notExisting.ttl'),

--- a/test/integration/patch-test.js
+++ b/test/integration/patch-test.js
@@ -79,7 +79,7 @@ describe('PATCH through text/n3', () => {
       patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
-      status: 200,
+      status: 201,
       text: 'Patch applied successfully',
       result: '@prefix : </new.ttl#>.\n@prefix tim: </>.\n\ntim:x tim:y tim:z.\n\n'
     }))
@@ -90,7 +90,7 @@ describe('PATCH through text/n3', () => {
       patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
-      status: 200,
+      status: 201,
       text: 'Patch applied successfully',
       // result: '{\n  "@id": "/x",\n  "/y": {\n    "@id": "/z"\n  }\n}'
       result: `{
@@ -110,7 +110,7 @@ describe('PATCH through text/n3', () => {
       patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
-      status: 200,
+      status: 201,
       text: 'Patch applied successfully',
       result: `<rdf:RDF
  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -126,7 +126,7 @@ describe('PATCH through text/n3', () => {
       patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
-      status: 200,
+      status: 201,
       text: 'Patch applied successfully',
       result: '@prefix : </new.n3#>.\n@prefix tim: </>.\n\ntim:x tim:y tim:z.\n\n'
     }))
@@ -186,7 +186,7 @@ describe('PATCH through text/n3', () => {
       patch: `<> a solid:InsertDeletePatch;
         solid:inserts { <x> <y> <z>. }.`
     }, {
-      status: 200,
+      status: 201,
       text: 'Patch applied successfully',
       result: '@prefix : <#>.\n@prefix fol: <./>.\n\nfol:x fol:y fol:z.\n\n'
     }))


### PR DESCRIPTION
A PATCH request may end up creating a new resource, in which case a 201 status code should be returned.

This is an equivalent change as that for PUT in #1785. 

This does not update or add tests, please fix that!