### PR TITLE
Use Double Quotes in package.json > scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   "scripts": {
     "build": "echo nothing to build",
     "solid": "node ./bin/solid",
-    "standard": "standard '{bin,examples,lib,test}/**/*.js'",
+    "standard": "standard \"{bin,examples,lib,test}/**/*.js\"",
     "validate": "node ./test/validate-turtle.js",
     "nyc": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 nyc --reporter=text-summary mocha --recursive test/integration/ test/unit/",
     "mocha": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 mocha --recursive test/integration/ test/unit/",


### PR DESCRIPTION
Changed single quote to double quote when invoking Standard in package.json > scripts, as single quotes do not work on Windows.