### PR TITLE
security: add ACL check for WebSocket subscriptions

### DIFF
--- a/lib/create-server.mjs
+++ b/lib/create-server.mjs
@@ -6,6 +6,8 @@ import SolidWs from 'solid-ws'
 import globalTunnel from 'global-tunnel-ng'
 import debug from './debug.mjs'
 import createApp from './create-app.mjs'
+import ACLChecker from './acl-checker.mjs'
+import url from 'url'
 
 function createServer (argv, app) {
   argv = argv || {}
@@ -96,7 +98,46 @@ function createServer (argv, app) {
 
   // Setup Express app
   if (ldp.live) {
-    const solidWs = SolidWs(server, ldpApp)
+    // Authorization callback for WebSocket subscriptions
+    // Checks ACL read permission before allowing subscription
+    const authorizeSubscription = function (iri, req, callback) {
+      // TODO: Extract userId from session cookie or Authorization header
+      // For now, treat all WebSocket connections as anonymous
+      // This still prevents anonymous access to private resources
+      const userId = null
+
+      try {
+        const parsedUrl = url.parse(iri)
+        const resourcePath = decodeURIComponent(parsedUrl.pathname)
+        const hostname = parsedUrl.hostname || req.headers.host?.split(':')[0]
+        const rootUrl = ldp.resourceMapper.resolveUrl(hostname)
+        const resourceUrl = rootUrl + resourcePath
+
+        // Create a minimal request-like object for ACLChecker
+        const pseudoReq = {
+          hostname,
+          path: resourcePath,
+          get: (header) => req.headers[header.toLowerCase()]
+        }
+
+        const aclChecker = ACLChecker.createFromLDPAndRequest(resourceUrl, ldp, pseudoReq)
+
+        aclChecker.can(userId, 'Read')
+          .then(allowed => {
+            debug.ACL(`WebSocket subscription ${allowed ? 'allowed' : 'denied'} for ${iri} (user: ${userId || 'anonymous'})`)
+            callback(null, allowed)
+          })
+          .catch(err => {
+            debug.ACL(`WebSocket ACL check error for ${iri}: ${err.message}`)
+            callback(null, false)
+          })
+      } catch (err) {
+        debug.ACL(`WebSocket authorization error: ${err.message}`)
+        callback(null, false)
+      }
+    }
+
+    const solidWs = SolidWs(server, ldpApp, { authorize: authorizeSubscription })
     ldpApp.locals.ldp.live = solidWs.publish.bind(solidWs)
   }
 


### PR DESCRIPTION
## Summary

Check WAC read permission before allowing WebSocket subscriptions. This prevents information leakage via notifications to unauthorized users.

## Changes

- Add `authorizeSubscription` callback for solid-ws
- Check ACL read access before allowing subscription
- Denied subscriptions receive `err <url> forbidden`
- Currently treats all WS connections as anonymous (see note below)

## Dependencies

⚠️ **This PR requires nodeSolidServer/node-solid-ws#29 to be merged and released first.**

The solid-ws package needs the new `authorize` callback option before this can work.

## Future enhancement

Currently all WebSocket connections are treated as anonymous for ACL purposes. This still prevents the main vulnerability (anonymous users subscribing to private resources).

Full authenticated WebSocket subscriptions would require either:
- Parsing session cookies and looking up the session
- Validating Authorization header bearer tokens

This can be added in a follow-up PR.

Fixes #1334